### PR TITLE
fix localized loop var typo

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -110,7 +110,7 @@ __bp_in_prompt_command() {
     local trimmed_arg
     trimmed_arg=$(__bp_trim_whitespace "$1")
 
-    local prompt_command_function
+    local command
     for command in "${prompt_command_array[@]}"; do
         local trimmed_command
         trimmed_command=$(__bp_trim_whitespace "$command")


### PR DESCRIPTION
very minor, the loop var wasn't actually being unset because of a name mismatch