### PR TITLE
Store existing PROMPT_COMMAND without subshells

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -203,7 +203,9 @@ __bp_preexec_and_precmd_install() {
     local existing_prompt_command
 
     if [[ -n "$PROMPT_COMMAND" ]]; then
-        existing_prompt_command=$(echo "$PROMPT_COMMAND" | sed '/; *$/!s/$/;/')
+        existing_prompt_command=${PROMPT_COMMAND%${PROMPT_COMMAND##*[![:space:]]}}
+        existing_prompt_command=${existing_prompt_command%;}
+        existing_prompt_command=${existing_prompt_command/%/;}
     else
         existing_prompt_command=""
     fi


### PR DESCRIPTION
Tested with:

```sh
% bash --version
GNU bash, version 4.3.42(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```