### PR TITLE
Store history 1 without sed

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -160,7 +160,8 @@ __bp_preexec_invoke_exec() {
         return
     fi
 
-    local this_command="$(HISTTIMEFORMAT= history 1 | sed -e "s/^[ ]*[0-9]*[ ]*//g")";
+    local this_command
+    read -r _ this_command < <(HISTTIMEFORMAT= history 1);
 
     # Sanity check to make sure we have something to invoke our function with.
     if [[ -z "$this_command" ]]; then


### PR DESCRIPTION
Tested with:

```sh
% bash --version
GNU bash, version 4.3.42(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```