### PR TITLE
test precmd_function without test compound command and command substitution

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -85,10 +85,11 @@ __bp_precmd_invoke_cmd() {
 
     # For every function defined in our function array. Invoke it.
     local precmd_function
-    for precmd_function in ${precmd_functions[@]}; do
+    for precmd_function in "${precmd_functions[@]}"; do
 
         # Only execute this function if it actually exists.
-        if [[ -n $(type -t $precmd_function) ]]; then
+        # Test existence of functions with: declare -[Ff]
+        if type -t "$precmd_function" 1>/dev/null; then
             __bp_set_ret_value $ret_value
             $precmd_function
         fi


### PR DESCRIPTION
Tested with:

```sh
% bash --version
GNU bash, version 4.3.42(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```