### PR TITLE
test preexec_function without test compound command and command substitution

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -176,7 +176,8 @@ __bp_preexec_invoke_exec() {
     for preexec_function in "${preexec_functions[@]}"; do
 
         # Only execute each function if it actually exists.
-        if [[ -n $(type -t $preexec_function) ]]; then
+        # Test existence of function with: declare -[fF]
+        if type -t "$preexec_function" 1>/dev/null; then
             $preexec_function "$this_command"
         fi
     done


### PR DESCRIPTION
Tested with:

```sh
% bash --version
GNU bash, version 4.3.42(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```