### PR TITLE
Don't clobber $_

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -43,6 +43,7 @@ __bp_imported="defined"
 # Should be available to each precmd and preexec
 # functions, should they want it.
 __bp_last_ret_value="$?"
+__bp_last_argument_prev_command="$_"
 
 # Command to set our preexec trap. It's invoked once via
 # PROMPT_COMMAND and then removed.
@@ -97,7 +98,7 @@ __bp_precmd_invoke_cmd() {
         # Only execute this function if it actually exists.
         # Test existence of functions with: declare -[Ff]
         if type -t "$precmd_function" 1>/dev/null; then
-            __bp_set_ret_value $__bp_last_ret_value
+            __bp_set_ret_value "$__bp_last_ret_value" "$__bp_last_argument_prev_command"
             $precmd_function
         fi
     done
@@ -140,7 +141,7 @@ __bp_preexec_invoke_exec() {
 
     # Save the contents of $_ so that it can be restored later on.
     # https://stackoverflow.com/questions/40944532/bash-preserve-in-a-debug-trap#40944702
-    local last_argument_prev_command="$1"
+    __bp_last_argument_prev_command="$1"
 
     # Checks if the file descriptor is not standard out (i.e. '1')
     # __bp_delay_install checks if we're in test. Needed for bats to run.
@@ -201,7 +202,7 @@ __bp_preexec_invoke_exec() {
     done
 
     # Restore the last argument of the last executed command
-    : "$last_argument_prev_command"
+    : "$__bp_last_argument_prev_command"
 }
 
 # Returns PROMPT_COMMAND with a semicolon appended

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -45,8 +45,9 @@ __bp_imported="defined"
 __bp_last_ret_value="$?"
 
 # Command to set our preexec trap. It's invoked once via
-# PROMPT_COMMAND and then removed.
-__bp_trap_install_string="trap '__bp_preexec_invoke_exec' DEBUG;"
+# PROMPT_COMMAND and then removed. This is the quoted form of the string:
+# trap '__bp_preexec_invoke_exec "$_"' DEBUG;
+__bp_trap_install_string="trap '__bp_preexec_invoke_exec \"\$_\"' DEBUG;"
 
 # Remove ignorespace and or replace ignoreboth from HISTCONTROL
 # so we can accurately invoke preexec with a command from our
@@ -137,6 +138,11 @@ __bp_in_prompt_command() {
 # interactively, and invoke 'preexec' if so.
 __bp_preexec_invoke_exec() {
 
+    # Save the contents of $_ so that it can be restored later on.
+    # See https://stackoverflow.com/questions/40944532/bash-preserve-in-a-debug-trap#40944702
+    # for an example of why this is required
+    local old_=$1
+
     # Checks if the file descriptor is not standard out (i.e. '1')
     # __bp_delay_install checks if we're in test. Needed for bats to run.
     # Prevents preexec from being invoked for functions in PS1
@@ -194,6 +200,8 @@ __bp_preexec_invoke_exec() {
             $preexec_function "$this_command"
         fi
     done
+
+    : "$old_" # restore $_ (last argument of last command executed)
 }
 
 # Returns PROMPT_COMMAND with a semicolon appended
@@ -253,7 +261,7 @@ __bp_install() {
     # Install our hooks in PROMPT_COMMAND to allow our trap to know when we've
     # actually entered something.
     PROMPT_COMMAND="__bp_precmd_invoke_cmd; ${existing_prompt_command} __bp_interactive_mode;"
-    trap '__bp_preexec_invoke_exec' DEBUG;
+    trap '__bp_preexec_invoke_exec "$_"' DEBUG;
 
     # Add two functions to our arrays for convenience
     # of definition.

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -45,8 +45,7 @@ __bp_imported="defined"
 __bp_last_ret_value="$?"
 
 # Command to set our preexec trap. It's invoked once via
-# PROMPT_COMMAND and then removed. This is the quoted form of the string:
-# trap '__bp_preexec_invoke_exec "$_"' DEBUG;
+# PROMPT_COMMAND and then removed.
 __bp_trap_install_string="trap '__bp_preexec_invoke_exec \"\$_\"' DEBUG;"
 
 # Remove ignorespace and or replace ignoreboth from HISTCONTROL
@@ -138,11 +137,6 @@ __bp_in_prompt_command() {
 # interactively, and invoke 'preexec' if so.
 __bp_preexec_invoke_exec() {
 
-    # Save the contents of $_ so that it can be restored later on.
-    # See https://stackoverflow.com/questions/40944532/bash-preserve-in-a-debug-trap#40944702
-    # for an example of why this is required
-    local old_=$1
-
     # Checks if the file descriptor is not standard out (i.e. '1')
     # __bp_delay_install checks if we're in test. Needed for bats to run.
     # Prevents preexec from being invoked for functions in PS1
@@ -200,8 +194,6 @@ __bp_preexec_invoke_exec() {
             $preexec_function "$this_command"
         fi
     done
-
-    : "$old_" # restore $_ (last argument of last command executed)
 }
 
 # Returns PROMPT_COMMAND with a semicolon appended
@@ -261,7 +253,7 @@ __bp_install() {
     # Install our hooks in PROMPT_COMMAND to allow our trap to know when we've
     # actually entered something.
     PROMPT_COMMAND="__bp_precmd_invoke_cmd; ${existing_prompt_command} __bp_interactive_mode;"
-    trap '__bp_preexec_invoke_exec "$_"' DEBUG;
+    eval "$__bp_trap_install_string"
 
     # Add two functions to our arrays for convenience
     # of definition.

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -137,6 +137,11 @@ __bp_in_prompt_command() {
 # interactively, and invoke 'preexec' if so.
 __bp_preexec_invoke_exec() {
 
+
+    # Save the contents of $_ so that it can be restored later on.
+    # https://stackoverflow.com/questions/40944532/bash-preserve-in-a-debug-trap#40944702
+    local last_argument_prev_command="$1"
+
     # Checks if the file descriptor is not standard out (i.e. '1')
     # __bp_delay_install checks if we're in test. Needed for bats to run.
     # Prevents preexec from being invoked for functions in PS1
@@ -194,6 +199,9 @@ __bp_preexec_invoke_exec() {
             $preexec_function "$this_command"
         fi
     done
+
+    # Restore the last argument of the last executed command
+    : "$last_argument_prev_command"
 }
 
 # Returns PROMPT_COMMAND with a semicolon appended

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -28,7 +28,7 @@ test_preexec_echo() {
 }
 
 @test "__bp_install should remove trap and itself from PROMPT_COMMAND" {
-  trap_string="trap '__bp_preexec_invoke_exec' DEBUG;"
+  trap_string="trap '__bp_preexec_invoke_exec \"\$_\"' DEBUG;"
   PROMPT_COMMAND="some_other_function; $trap_string __bp_install;"
 
   [[ $PROMPT_COMMAND  == *"$trap_string"* ]]

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -185,3 +185,9 @@ test_preexec_echo() {
     [[ $status == 0 ]]
     [[ "$output" == "$git_command" ]]
 }
+
+@test 'preexec should preserve $_' {
+    preexec_functions+=(test_echo)
+    : expected
+    [[ $_ = expected ]]
+}

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -96,6 +96,19 @@ test_preexec_echo() {
     [[ "$output" == "251" ]]
 }
 
+@test "precmd should set $_ to be the previous last arg" {
+    echo_last_arg() {
+      echo "$_"
+    }
+    precmd_functions+=(echo_last_arg)
+
+    __bp_last_argument_prev_command="last-arg"
+
+    run '__bp_precmd_invoke_cmd'
+    [[ $status == 0 ]]
+    [[ "$output" == "last-arg" ]]
+}
+
 
 @test "preexec should execute a function with the last command in our history" {
     preexec_functions+=(test_preexec_echo)

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -185,9 +185,3 @@ test_preexec_echo() {
     [[ $status == 0 ]]
     [[ "$output" == "$git_command" ]]
 }
-
-@test 'preexec should preserve $_' {
-    preexec_functions+=(test_echo)
-    : expected
-    [[ $_ = expected ]]
-}


### PR DESCRIPTION
`$_` should give the last argument of the last command. 

Currently it gives `__bp_preexec_invoke_exec`:
```
$ exec bash
$ . ./bash-preexec.sh
$ preexec() { echo "just typed $1"; }
$ echo $_
just typed echo $_
__bp_preexec_invoke_exec
$
```

Fix this to produce the expected behaviour:
```
exec bash
$ . ./bash-preexec.sh
$ preexec() { echo "just typed $1"; }
$ echo $_
just typed echo $_
./bash-preexec.sh
```

Note that `bash-bats` currently suffers from the *same bug* (it's a **feature** of bash), so the newly added test fails. I have manually tested it and it passes.