### PR TITLE
Initalize preexec_ret_value to prevent error

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -191,7 +191,7 @@ __bp_preexec_invoke_exec() {
 
     # For every function defined in our function array. Invoke it.
     local preexec_function
-    local preexec_ret_value
+    local preexec_ret_value=0
     for preexec_function in "${preexec_functions[@]}"; do
 
         # Only execute each function if it actually exists.
@@ -208,7 +208,7 @@ __bp_preexec_invoke_exec() {
     # If `extdebug` is enabled a non-zero return value from the last function
     # in prexec causes the command not to execute
     # Run `shopt -s extdebug` to enable
-    __bp_set_ret_value $preexec_ret_value "$__bp_last_argument_prev_command"
+    __bp_set_ret_value "$preexec_ret_value" "$__bp_last_argument_prev_command"
 }
 
 # Returns PROMPT_COMMAND with a semicolon appended


### PR DESCRIPTION
Fixing a bug I introduced in #36. If `preexec_functions` was empty, the following error would occur.

```sh
bash-4.4$ source bash-preexec.sh 
bash-4.4$ true
bash: return: bash-preexec.sh: numeric argument required
bash-4.4$ 
```

I wasn't able to find a way to write a test for this behavior in Bats, if you have any idea how to observe the error within Bats let me know.