### PR TITLE
Remove trailing semicolon to allow appending to PROMPT_COMMANDS

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -267,7 +267,7 @@ __bp_install() {
 
     # Install our hooks in PROMPT_COMMAND to allow our trap to know when we've
     # actually entered something.
-    PROMPT_COMMAND="__bp_precmd_invoke_cmd; ${existing_prompt_command} __bp_interactive_mode;"
+    PROMPT_COMMAND="__bp_precmd_invoke_cmd; ${existing_prompt_command} __bp_interactive_mode"
     eval "$__bp_trap_install_string"
 
     # Add two functions to our arrays for convenience

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -41,6 +41,14 @@ test_preexec_echo() {
   [[ -z "$output" ]]
 }
 
+@test "\$PROMPT_COMMAND=\"\$PROMPT_COMMAND; foo\" should work" {
+    __bp_install
+
+    eval "$PROMPT_COMMAND=$PROMPT_COMMAND; true"
+
+    [[ -z "$output" ]]
+}
+
 @test "__bp_prompt_command_with_semi_colon should handle different PROMPT_COMMANDS" {
     # PROMPT_COMMAND of spaces
     PROMPT_COMMAND=" "


### PR DESCRIPTION
Before:
```sh
$ source bash-preexec.sh
$ PROMPT_COMMAND="$PROMPT_COMMAND; true"
bash: PROMPT_COMMAND: line 3: syntax error near unexpected token `;;'
bash: PROMPT_COMMAND: line 3: `__bp_precmd_invoke_cmd;  __bp_interactive_mode;; true'
$ 
```

After:
```sh
$ source bash-preexec.sh
$ PROMPT_COMMAND="$PROMPT_COMMAND; true"
$ declare -p PROMPT_COMMAND
declare -- PROMPT_COMMAND="__bp_precmd_invoke_cmd;  __bp_interactive_mode; true"
$ 
```