### PR TITLE
Fix two tests in bash-preexec.bats.

### DIFF
--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -38,15 +38,13 @@ test_preexec_echo() {
 
   [[ $PROMPT_COMMAND  != *"$trap_string"* ]]
   [[ $PROMPT_COMMAND  != *"__bp_install;"* ]]
-  [[ -z "$output" ]]
 }
 
-@test "\$PROMPT_COMMAND=\"\$PROMPT_COMMAND; foo\" should work" {
+@test "PROMPT_COMMAND=\"\$PROMPT_COMMAND; foo\" should work" {
     __bp_install
 
-    eval "$PROMPT_COMMAND=$PROMPT_COMMAND; true"
-
-    [[ -z "$output" ]]
+    PROMPT_COMMAND="$PROMPT_COMMAND; true"
+    eval "$PROMPT_COMMAND"
 }
 
 @test "__bp_prompt_command_with_semi_colon should handle different PROMPT_COMMANDS" {


### PR DESCRIPTION
* There's no point checking $output if run isn't being called.
* Need to eval the value of $PROMPT_COMMAND separately from updating it.
  See https://github.com/rcaloras/bash-preexec/commit/64c6f53b52#commitcomment-23327269