### PR TITLE
Ensure a pre-existing DEBUG trap is preserved as a preexec function.

### DIFF
--- a/test/include-test.bats
+++ b/test/include-test.bats
@@ -6,7 +6,7 @@
   [[ -z $(type -t __bp_preexec_and_precmd_install) ]]
 }
 
-@test "should import of not defined" {
+@test "should import if not defined" {
   unset __bp_imported
   source "${BATS_TEST_DIRNAME}/../bash-preexec.sh"
   [[ -n $(type -t __bp_install) ]]


### PR DESCRIPTION
* Capture any pre-existing PROMPT_COMMAND hook in the same way, adding it as a precmd function.
* No longer need to do string manipulations of the PROMPT_COMMAND's contents.
* Added a unit test of the new trapping semantics.
* Tidied up some other tests to test the public API and avoid tweaking internal state
  (e.g. the old $_ test would fail to catch a bug in this change).

Resolves issue #39.