### PR TITLE
Fix #64 by quoting functions and set IFS on read

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -106,7 +106,7 @@ __bp_precmd_invoke_cmd() {
         # Test existence of functions with: declare -[Ff]
         if type -t "$precmd_function" 1>/dev/null; then
             __bp_set_ret_value "$__bp_last_ret_value" "$__bp_last_argument_prev_command"
-            $precmd_function
+            "$precmd_function"
         fi
     done
 }
@@ -189,7 +189,7 @@ __bp_preexec_invoke_exec() {
     fi
 
     local this_command
-    this_command=$(HISTTIMEFORMAT= builtin history 1 | { read -r _ this_command; echo "$this_command"; })
+    this_command=$(HISTTIMEFORMAT= builtin history 1 | { IFS=" " read -r _ this_command; echo "$this_command"; })
 
     # Sanity check to make sure we have something to invoke our function with.
     if [[ -z "$this_command" ]]; then
@@ -210,7 +210,7 @@ __bp_preexec_invoke_exec() {
         # Test existence of function with: declare -[fF]
         if type -t "$preexec_function" 1>/dev/null; then
             __bp_set_ret_value $__bp_last_ret_value
-            $preexec_function "$this_command"
+            "$preexec_function" "$this_command"
             preexec_function_ret_value="$?"
             if [[ "$preexec_function_ret_value" != 0 ]]; then
                 preexec_ret_value="$preexec_function_ret_value"

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -162,6 +162,26 @@ test_preexec_echo() {
     [[ "${lines[1]}" == "two" ]]
 }
 
+@test "preexec should execute a function with IFS defined to local scope" {
+    IFS=_
+    name_with_underscores_1() { parts=(1_2); echo $parts; }
+    preexec_functions+=(name_with_underscores_1)
+
+    __bp_interactive_mode
+    run '__bp_preexec_invoke_exec'
+    [[ $status == 0 ]]
+    [[ "$output" == "1 2" ]]
+}
+
+@test "precmd should execute a function with IFS defined to local scope" {
+    IFS=_
+    name_with_underscores_2() { parts=(2_2); echo $parts; }
+    precmd_functions+=(name_with_underscores_2)
+    run '__bp_precmd_invoke_cmd'
+    [[ $status == 0 ]]
+    [[ "$output" == "2 2" ]]
+}
+
 @test "preexec should set \$? to be the exit code of preexec_functions" {
     return_nonzero() {
       return 1


### PR DESCRIPTION
- Fixes bug where IFS in outer environment could be set to something that
  would cause our inner functions to break on varibale expansion.

- Added a couple unit tests.