### PR TITLE
Drop the misleading shebang

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # bash-preexec.sh -- Bash support for ZSH-like 'preexec' and 'precmd' functions.
 # https://github.com/rcaloras/bash-preexec
 #


### PR DESCRIPTION
The `bash-preexec.sh` script is supposed to be sourced into a Bash and
never meant to be run as a standalone script. However, shebangs are
meant as a hint to the program loader to select the proper binary if
executing a text file as if it were one. Thus, the shebang in this
script will never be evaluated and might actually mislead users to
execute instead of source this script. Some distros frown at this.
E.g., openSUSE lints packages for such scripts and generates a warning.