### PR TITLE
Fix issues with capturing certain commands

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -199,7 +199,7 @@ __bp_preexec_invoke_exec() {
     fi
 
     local this_command
-    this_command=$(HISTTIMEFORMAT= builtin history 1 | { IFS=" " read -r _ this_command; echo "$this_command"; })
+    this_command=$(HISTTIMEFORMAT= builtin history 1 | sed -E '1 s/^ *[0-9]+[* ] //')
 
     # Sanity check to make sure we have something to invoke our function with.
     if [[ -z "$this_command" ]]; then

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -17,7 +17,7 @@ test_echo() {
 }
 
 test_preexec_echo() {
-  echo "$1"
+  printf "%s\n" "$1"
 }
 
 @test "__bp_install_after_session_init should exit with 1 if we're not using bash" {
@@ -244,4 +244,34 @@ test_preexec_echo() {
     run '__bp_preexec_invoke_exec'
     [[ $status == 0 ]]
     [[ "$output" == "$git_command" ]]
+}
+
+@test "preexec should not strip whitespace from commands" {
+    preexec_functions+=(test_preexec_echo)
+    __bp_interactive_mode
+    history -s " this command has whitespace "
+
+    run '__bp_preexec_invoke_exec'
+    [[ $status == 0 ]]
+    [[ "$output" == " this command has whitespace " ]]
+}
+
+@test "preexec should preserve multi-line strings in commands" {
+    preexec_functions+=(test_preexec_echo)
+    __bp_interactive_mode
+    history -s "this 'command contains
+a multiline string'"
+    run '__bp_preexec_invoke_exec'
+    [[ $status == 0 ]]
+    [[ "$output" == "this 'command contains
+a multiline string'" ]]
+}
+
+@test "preexec should work on options to 'echo' commands" {
+    preexec_functions+=(test_preexec_echo)
+    __bp_interactive_mode
+    history -s -- '-n'
+    run '__bp_preexec_invoke_exec'
+    [[ $status == 0 ]]
+    [[ "$output" == '-n' ]]
 }


### PR DESCRIPTION
This uses a sed-based regex instead of the read builtin to drop the initial number output by the 'history' command.

The problems with the read builtin are:
  - It only reads a single line.
  - It strips whitespace.

Changing to this sed expression (which removes the initial number from the first line only, assuming that the format of the history line is "%5d%c %s%s\n" as in history.def in the bash source code) resolves both of these issues, fixing #77 and #78 .

This also removes the need for either an echo or a printf, and so also incidentally resolves #76 . (As pointed out on that issue, this could also have been fixed without switching to sed.)

Adds regression tests for the fixed issues. The test code is also adjusted to not have the same echo/printf issue.