### PR TITLE
Miscellaneous fixes for sed.

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -203,6 +203,7 @@ __bp_preexec_invoke_exec() {
 
     local this_command
     this_command=$(
+        export LC_ALL=C
         HISTTIMEFORMAT= builtin history 1 | sed '1 s/^ *[0-9][0-9]*[* ] //'
     )
 

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -202,7 +202,9 @@ __bp_preexec_invoke_exec() {
     fi
 
     local this_command
-    this_command=$(HISTTIMEFORMAT= builtin history 1 | sed '1 s/^ *[0-9]\+[* ] //')
+    this_command=$(
+        HISTTIMEFORMAT= builtin history 1 | sed '1 s/^ *[0-9][0-9]*[* ] //'
+    )
 
     # Sanity check to make sure we have something to invoke our function with.
     if [[ -z "$this_command" ]]; then


### PR DESCRIPTION
1. Avoid using `\+` because it's not available on some BSDs.
2. Set the locale to avoid number formatting issues.