### PR TITLE
Honor HISTCONTROL "ignorespace" and "ignoreboth"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec
 echo '[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh' >> ~/.bashrc
 ```
 
+NOTE: this script may change your `HISTCONTROL` value by replacing `ignorespace` with `bash-preexec_ignorespace` or replacing `ignoreboth` with `ignoredups:bash-preexec_ignorespace`.  See [`HISTCONTROL` interaction](#histcontrol-interaction) for details.
+
 ## Usage
 Two functions **preexec** and **precmd** can now be defined and they'll be automatically invoked by bash-preexec if they exist.
 
@@ -90,6 +92,35 @@ bash-preexec does not support invoking preexec() for subshells by default. It mu
 export __bp_enable_subshells="true"
 ```
 This is disabled by default due to buggy situations related to to `functrace` and Bash's `DEBUG trap`. See [Issue #25](https://github.com/rcaloras/bash-preexec/issues/25)
+
+## `HISTCONTROL` interaction
+
+In order to be able to provide the last command text to the `preexec` hook, this
+script uses the command history. It reads the last command from the list of the
+executed commands.  If your `HISTCONTROL` contains `ignorespace` (or
+`ignoreboth`), commands that start with a space are not added into the command
+history. When the pre-exec hook is invoked, it can not tell if the last value
+read from the command history is actually the command executed, or if the last
+executed command was hidden, and the command history contains an older command.
+
+To solve this problem, when bash-preexec is loaded, it will check for
+`ignorespace` and `ignoreboth` values in the `HISTCONTROL` variable and replace
+them with `bash-preexec_ignorespace` and `ignoredups:bash-preexec_ignorespace`,
+respectively. It will also show a note once, that this substitution has been
+performed, unless you also set `BP_HISTCONTROL_ACK` to a non-empty value.
+
+When the preexec hook is invoked, there are 3 possibilities now:
+1. `HISTCONTROL` contains `ignorespace` or `ignoreboth`. In this case
+   bash-preexec can not reliably determine the last executed command. The hook
+   will show a notice once, and will be executed with an empty last command.
+   You can avoid the notice completely if you set `BP_EMPTY_LAST_COMMAND_ACK`.
+2. `HISTCONTROL` contains `bash-preexec_ignorespace`. In this case the hook will
+   read the last command from the command history and will remove it from the
+   history if it is prefixed with a whitespace. The hook will be executed with
+   the command text, even if it is a whitespace prefixed command.
+3. `HISTCONTROL` does not contain `ignorespace`, `ignoreboth`, or
+   `bash-preexec_ignorespace`. In this case the hook will read the last command
+   from the command history and run the hook with the last command.
 
 ## Library authors
 If you want to detect bash-preexec in your library (for example, to add hooks to `preexec_functions` when available), use the Bash variable `bash_preexec_imported`:

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -86,18 +86,29 @@ __bp_require_not_readonly() {
     done
 }
 
-# Remove ignorespace and or replace ignoreboth from HISTCONTROL
-# so we can accurately invoke preexec with a command from our
-# history even if it starts with a space.
+# Replace "ignorespace" and/or "ignoreboth" in HISTCONTROL with
+# "bash-preexec_ignorespace" and "ignoredups:bash-preexec_ignorespace"
+# respectively.  This is necessary in order for the preexec hook to be able to
+# read the last command from the history, even if it starts with a space.  We
+# then remove commands that start with a space from the history in
+# __bp_load_this_command_from_history, if "bash-preexec_ignorespace" is part of
+# HISTCONTROL.
 __bp_adjust_histcontrol() {
     local histcontrol
-    histcontrol="${HISTCONTROL:-}"
-    histcontrol="${histcontrol//ignorespace}"
-    # Replace ignoreboth with ignoredups
-    if [[ "$histcontrol" == *"ignoreboth"* ]]; then
-        histcontrol="ignoredups:${histcontrol//ignoreboth}"
-    fi
-    export HISTCONTROL="$histcontrol"
+    histcontrol=${HISTCONTROL:-}
+
+    # We might need to delete some of the elements.  It is easier when each
+    # elements has it's own set of separators.
+    histcontrol=":${histcontrol//:/::}:"
+
+    histcontrol=${histcontrol//:ignorespace:/:bash-preexec_ignorespace:}
+    histcontrol=${histcontrol//:ignoreboth:/:ignoredups::bash-preexec_ignorespace:}
+
+    histcontrol=${histcontrol//::/:}
+    histcontrol=${histcontrol#:}
+    histcontrol=${histcontrol%:}
+
+    export HISTCONTROL=$histcontrol
 }
 
 # This variable describes whether we are currently in "interactive mode";
@@ -310,9 +321,69 @@ __bp_in_prompt_command() {
     return 1
 }
 
+# Loads the last executed command from the command history, assiging it into the
+# $this_command variable.
+#
+# If $HISTCONTROL contains "ignorespace", $this_command will be set to an empty
+# string.
+#
+# If $HISTCONTROL contains "bash-preexec_ignorespace", removes the extacted
+# command from the command history, if the command starts with a space.  This
+# simulates the built-in "ignorespace" behavior.
 __bp_load_this_command_from_history() {
-    this_command=$(LC_ALL=C HISTTIMEFORMAT='' builtin history 1)
-    this_command="${this_command#*[[:digit:]][* ] }"
+    local histcontrol
+    histcontrol=${HISTCONTROL:-}
+
+    local ignorespace=''
+
+    # If ignorespace is in $HISTCONTROL, we do not know if the last command in
+    # the history is actually the last executed command.  But it is up to the 
+    if [[ "$histcontrol" =~ (^|:)ignorespace(:|$) \
+        || "$histcontrol" =~ (^|:)ignoreboth(:|$) ]];
+    then
+        if [[ -z "${BP_EMPTY_LAST_COMMAND_ACK:-}" ]]; then
+            cat <<EOM >&2
+bash-preexec: WARNING: HISTCONTROL contains "ignorespace", or "ignoreboth"
+    making it impossible to reliably detect the last executed command.
+    bash-preexec will invoke hook functions with an empty command.
+
+    If this is intentional, set BP_EMPTY_LAST_COMMAND_ACK to avoid this warning:
+
+export BP_EMPTY_LAST_COMMAND_ACK=yes
+
+    You can also replace "ignorespace" with "bash-preexec_ignorespace", to
+    workaround this restriction.  See "\`HISTCONTROL\` interaction" in the
+    bash-preexec documentation.
+EOM
+        fi
+
+        export BP_EMPTY_LAST_COMMAND_ACK=yes
+
+        this_command=''
+        return 0
+    elif [[ "$histcontrol" =~ (^|:)bash-preexec_ignorespace(:|$) ]]; then
+        ignorespace=yes
+    fi
+
+    local history_last_entry
+    history_last_entry=$(LC_ALL=C HISTTIMEFORMAT='' builtin history 1)
+    this_command="${history_last_entry#*[[:digit:]][* ] }"
+
+    # "bash-preexec_ignorespace" in HISTCONTROL indicates we have removed
+    # "ignorespace" from HISTCONTROL, and we need to remove commands that start
+    # with a space from the history ourselves.
+    #
+    # With bash 5.0 or above, we could have just ran
+    #
+    #   builtin history -d -1
+    #
+    # Negative indices for `-d` are not supported before 5.0, so we compute the
+    # length of the history list explicit, to delete the last entry.
+    if [[ -n "$ignorespace" && "$this_command" == " "* ]]; then
+        if [[ "$history_last_entry" =~ ^[[:blank:]]*([0-9]+) ]]; then
+            builtin history -d "${BASH_REMATCH[1]}"
+        fi
+    fi
 
     # Sanity check to make sure we have something to invoke our function with.
     [[ -n "$this_command" ]]

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -587,24 +587,170 @@ set_exit_code_and_run_precmd() {
 
 }
 
-@test "__bp_adjust_histcontrol should remove ignorespace and ignoreboth" {
+@test "__bp_adjust_histcontrol shows nothing when \$HISTCONTROL is untouched" {
+    HISTCONTROL="ignoredups"
+    run '__bp_adjust_histcontrol'
+    [ "$output" == '' ]
+}
 
-    # Should remove ignorespace
+@test "__bp_adjust_histcontrol changes ignorespace to bash-preexec_ignorespace" {
+    # Should not touch `ignoredups`.
+    HISTCONTROL="selection_flag1:ignoredups:selection_flag2:"
+    __bp_adjust_histcontrol
+    [ "$HISTCONTROL" == "selection_flag1:ignoredups:selection_flag2:" ]
+
+    # Should replace ignorespace on its own.
+    HISTCONTROL="ignorespace"
+    __bp_adjust_histcontrol
+    [ "$HISTCONTROL" == "bash-preexec_ignorespace" ]
+
+    # Should replace ignorespace.
     HISTCONTROL="ignorespace:ignoredups:*"
     __bp_adjust_histcontrol
-    [ "$HISTCONTROL" == ":ignoredups:*" ]
+    [ "$HISTCONTROL" == "bash-preexec_ignorespace:ignoredups:*" ]
 
-    # Should remove ignoreboth and replace it with ignoredups
+    # Should replace all ignorespace instances.
+    HISTCONTROL="ignorespace:ignoredups:something_else:ignorespace:more_stuff"
+    __bp_adjust_histcontrol
+    [ "$HISTCONTROL" == "bash-preexec_ignorespace:ignoredups:something_else:bash-preexec_ignorespace:more_stuff" ]
+
+}
+
+@test "__bp_adjust_histcontrol changes ignoreboth to ignoredups:bash-preexec_ignorespace" {
+    # Should replace ignoreboth on its own.
     HISTCONTROL="ignoreboth"
     __bp_adjust_histcontrol
-    [ "$HISTCONTROL" == "ignoredups:" ]
+    [ "$HISTCONTROL" == "ignoredups:bash-preexec_ignorespace" ]
 
-    # Handle a few inputs
-    HISTCONTROL="ignoreboth:ignorespace:some_thing_else"
+    # Should replace ignoreboth.
+    HISTCONTROL="ignoreboth:more_flags"
     __bp_adjust_histcontrol
-    echo "$HISTCONTROL"
-    [ "$HISTCONTROL" == "ignoredups:::some_thing_else" ]
+    [ "$HISTCONTROL" == "ignoredups:bash-preexec_ignorespace:more_flags" ]
 
+    # Should replace all ignoreboth instances.
+    HISTCONTROL="ignoreboth:something_else:ignoreboth:even_more_stuff"
+    __bp_adjust_histcontrol
+    [ "$HISTCONTROL" == "ignoredups:bash-preexec_ignorespace:something_else:ignoredups:bash-preexec_ignorespace:even_more_stuff" ]
+
+    # Should replace all ignoreboth and ignorespace instances.
+    HISTCONTROL="ignoreboth:something_else:ignorespace:more_stuff"
+    __bp_adjust_histcontrol
+    [ "$HISTCONTROL" == "ignoredups:bash-preexec_ignorespace:something_else:bash-preexec_ignorespace:more_stuff" ]
+
+    # Should replace all ignoreboth instances.
+    HISTCONTROL="ignoreboth:ignoredups:something_else:ignoreboth:more_stuff"
+    __bp_adjust_histcontrol
+    [ "$HISTCONTROL" == "ignoredups:bash-preexec_ignorespace:ignoredups:something_else:ignoredups:bash-preexec_ignorespace:more_stuff" ]
+
+}
+
+run_bp_load_this_command_from_history_and_print_it() {
+    local this_command
+    __bp_load_this_command_from_history
+    local status=$?
+    printf '%s\n' "$this_command"
+    return $status
+}
+
+@test "__bp_load_this_command_from_history: HISTCONTROL with no ignore" {
+    local command1="this command is in the history"
+    history -s "$command1"
+
+    run run_bp_load_this_command_from_history_and_print_it
+    [ $status -eq 0 ]
+    [ "$output" == "$command1" ]
+}
+
+run_bp_load_this_command_from_history_and_print_BP_EMPTY_LAST_COMMAND_ACK() {
+    local this_command
+    __bp_load_this_command_from_history
+    local status=$?
+    printf 'BP_EMPTY_LAST_COMMAND_ACK: %s\n' "$BP_EMPTY_LAST_COMMAND_ACK"
+    return $status
+}
+
+@test "__bp_load_this_command_from_history: HISTCONTROL with ignorespace shows a warning" {
+    HISTCONTROL="ignorespace"
+
+    local command1="this command is in the history"
+    history -s "$command1"
+
+    run run_bp_load_this_command_from_history_and_print_BP_EMPTY_LAST_COMMAND_ACK
+    [ $status -eq 0 ]
+    [[ "$output" =~ ^'bash-preexec: WARNING: HISTCONTROL contains "ignorespace"' ]] || return 1
+    [[ "$output" =~ 'BP_EMPTY_LAST_COMMAND_ACK: yes'$ ]] || return 1
+}
+
+run_bp_load_this_command_from_history_twice() {
+    __bp_load_this_command_from_history && __bp_load_this_command_from_history
+}
+
+@test "__bp_load_this_command_from_history: HISTCONTROL with ignorespace shows only one warning" {
+    HISTCONTROL="ignorespace"
+
+    local command1="this command is in the history"
+    history -s "$command1"
+
+    run run_bp_load_this_command_from_history_twice
+    [ $status -eq 0 ]
+    [[ "$output" =~ ^'bash-preexec: WARNING: ' ]] || return 1
+    [[ ! ( "$output" =~ ^'bash-preexec: WARNING: '.*'bash-preexec: WARNING' ) ]] || return 1
+}
+
+@test "__bp_load_this_command_from_history: HISTCONTROL with ignorespace shows no warning if acked" {
+    BP_EMPTY_LAST_COMMAND_ACK=yes
+    HISTCONTROL="ignorespace"
+
+    local command1="this command is in the history"
+    history -s "$command1"
+
+    run __bp_load_this_command_from_history
+    [ $status -eq 0 ]
+    [ "$output" == '' ]
+}
+
+run_bp_load_this_command_from_history_and_print_it_and_the_last_history_entry() {
+    local this_command
+    __bp_load_this_command_from_history
+    local status=$?
+
+    local history_last
+    history_last=$(LC_ALL=C HISTTIMEFORMAT='' builtin history 1)
+    history_last="${history_last#*[[:digit:]][* ] }"
+
+    printf '%s\n' "$this_command"
+    printf '%s\n' "$history_last"
+    return $status
+}
+
+@test "__bp_load_this_command_from_history: HISTCONTROL with bash-preexec_ignorespace" {
+    HISTCONTROL="bash-preexec_ignorespace"
+
+    local command1="this command is in the history"
+    history -s "$command1"
+
+    run run_bp_load_this_command_from_history_and_print_it_and_the_last_history_entry
+    [ $status -eq 0 ]
+    [ "$output" == "$command1"$'\n'"$command1" ]
+
+    local command2=" this should not be in the history"
+    history -s "$command2"
+
+    run run_bp_load_this_command_from_history_and_print_it_and_the_last_history_entry
+    [ $status -eq 0 ]
+    [ "$output" == "$command2"$'\n'"$command1" ]
+}
+
+@test "__bp_load_this_command_from_history: HISTCONTROL with ignorespace" {
+    BP_EMPTY_LAST_COMMAND_ACK=yes
+    HISTCONTROL="ignorespace"
+
+    local command1="this command is in the history"
+    history -s "$command1"
+
+    run run_bp_load_this_command_from_history_and_print_it
+    [ $status -eq 0 ]
+    [ "$output" == "" ]
 }
 
 @test "preexec should respect HISTTIMEFORMAT" {
@@ -647,4 +793,46 @@ a multiline string'" ]
     run '__bp_preexec_invoke_exec'
     [ $status -eq 0 ]
     [ "$output" == '-n' ]
+}
+
+run_bp_preexec_invoke_exec_print_last_history_entry() {
+    __bp_preexec_invoke_exec
+    local status=$?
+
+    local history_last
+    history_last=$(LC_ALL=C HISTTIMEFORMAT='' builtin history 1)
+    history_last="${history_last#*[[:digit:]][* ] }"
+
+    printf '%s\n' "$history_last"
+    return $status
+}
+
+@test "When HISTCONTROL contains ignorespace the ignorespace functionality is honoured" {
+    # This test covers functionality that is mostly already covered by
+    # __bp_adjust_histcontrol and __bp_load_this_command_from_history tests
+    # above.  But it represents a more complete, almost an end-to-end scenario,
+    # making sure that small components interact correctly as a whole.
+
+    preexec_functions+=(test_preexec_echo)
+    HISTCONTROL=ignorespace:ignoreboth
+
+    __bp_adjust_histcontrol
+
+    [ "$HISTCONTROL" == "bash-preexec_ignorespace:ignoredups:bash-preexec_ignorespace" ]
+
+    __bp_interactive_mode
+
+    command1="this command is in the history"
+
+    history -s "$command1"
+    run run_bp_preexec_invoke_exec_print_last_history_entry
+    [ $status == 0 ]
+    [ "$output" == "$command1"$'\n'"$command1" ]
+
+    command2=" this should not be in the history"
+
+    history -s "$command2"
+    run run_bp_preexec_invoke_exec_print_last_history_entry
+    [ $status == 0 ]
+    [ "$output" == "$command2"$'\n'"$command1" ]
 }


### PR DESCRIPTION
After 3458480385f81124a9fd9a38ff384e43dd815b1c

    Remove ignorespace from $HISTCONTROL

and after 7e55ac15fee86cdf8e08e966d8b8c9dd2bf7ad03

    Follow up commit for issue #6

    -Replace ignoreboth with simpley ignoredups

this script would remove 'ignorespace' and would replace 'ignoreboth'
with 'ignoredups'.  This effectively disables the functionality of not
adding space prefixed commands into history.  It used to happen
siliently and could be quite confusing to users who use this feature.

This script relies on the command to be in the history, but we can
mostly fix the issue by "manually" removing a whitespace prefixed command
from the history after reading it from there.