### PR TITLE
Tweak the syntax for clearing the DEBUG trap

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -321,7 +321,7 @@ __bp_install_after_session_init() {
     # invoked once.
     # It's necessary to clear any existing DEBUG trap in order to set it from the install function.
     # Using \n as it's the most universal delimiter of bash commands
-    PROMPT_COMMAND=$'\n__bp_trap_string="$(trap -p DEBUG)"\ntrap DEBUG\n__bp_install\n'
+    PROMPT_COMMAND=$'\n__bp_trap_string="$(trap -p DEBUG)"\ntrap - DEBUG\n__bp_install\n'
 }
 
 # Run our install so long as we're not delaying it.

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -39,7 +39,7 @@ test_preexec_echo() {
 @test "__bp_install should remove trap logic and itself from PROMPT_COMMAND" {
   __bp_install_after_session_init
 
-  [[ "$PROMPT_COMMAND" == *"trap DEBUG"* ]] || return 1
+  [[ "$PROMPT_COMMAND" == *"trap - DEBUG"* ]] || return 1
   [[ "$PROMPT_COMMAND" == *"__bp_install"* ]] || return 1
 
   eval "$PROMPT_COMMAND"


### PR DESCRIPTION
In a [`--posix` shell](https://www.gnu.org/software/bash/manual/html_node/Bash-POSIX-Mode.html) (e.g. a shell invoked as `sh` instead of `bash`) the ARG parameter is not optional:

> 41. The trap builtin doesn’t check the first argument for a possible signal specification and revert the signal handling to the original disposition if it is, unless that argument consists solely of digits and is a valid signal number. If users want to reset the handler for a given signal to the original disposition, they should use ‘-’ as the first argument.

It may not be the intent of bash-preexec to actively _support_ POSIX mode, but the failure behavior here is pretty bad:

```
$ bash --noprofile --norc --posix || echo BASH CRASHED
bash-5.0$ source bash_preexec.sh
trap: usage: trap [-lp] [[arg] signal_spec ...]
BASH CRASHED
```

So this small tweak seems worthwhile, even if POSIX mode ends up being incompatible for other reasons.

CC @lguelorget