### PR TITLE
Return immediately when not run in Bash

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -32,6 +32,11 @@
 #  using: the "DEBUG" trap, and the "PROMPT_COMMAND" variable. If you override
 #  either of these after bash-preexec has been installed it will most likely break.
 
+# Make sure this is bash that's running and return otherwise.
+if [[ -z "${BASH_VERSION:-}" ]]; then
+    return 1;
+fi
+
 # Avoid duplicate inclusion
 if [[ "${__bp_imported:-}" == "defined" ]]; then
     return 0
@@ -318,11 +323,6 @@ __bp_install() {
 # after our session has started. This allows bash-preexec to be included
 # at any point in our bash profile.
 __bp_install_after_session_init() {
-    # Make sure this is bash that's running this and return otherwise.
-    if [[ -z "${BASH_VERSION:-}" ]]; then
-        return 1;
-    fi
-
     # bash-preexec needs to modify these variables in order to work correctly
     # if it can't, just stop the installation
     __bp_require_not_readonly PROMPT_COMMAND HISTCONTROL HISTTIMEFORMAT || return

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -21,9 +21,9 @@ test_preexec_echo() {
   printf "%s\n" "$1"
 }
 
-@test "__bp_install_after_session_init should exit with 1 if we're not using bash" {
+@test "sourcing bash-preexec should exit with 1 if we're not using bash" {
   unset BASH_VERSION
-  run '__bp_install_after_session_init'
+  run source "${BATS_TEST_DIRNAME}/../bash-preexec.sh"
   [ $status -eq 1 ]
   [ -z "$output" ]
 }


### PR DESCRIPTION
- Return with an exit code of 1 when run in any shell other than Bash.
Should prevent any functions or variables from being defined. This check
was previously run later during initialization.

- Updated test case for this
- Should address #113