### PR TITLE
Handle unbound PROMPT_COMMAND

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -90,6 +90,10 @@ __bp_adjust_histcontrol() {
 # and unset as soon as the trace hook is run.
 __bp_preexec_interactive_mode=""
 
+# These arrays are used to add functions to be run before, or after, prompts.
+declare -a precmd_functions
+declare -a preexec_functions
+
 # Trims leading and trailing whitespace from $2 and writes it to the variable
 # name passed as $1
 __bp_trim_whitespace() {

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -159,7 +159,7 @@ __bp_set_ret_value() {
 __bp_in_prompt_command() {
 
     local prompt_command_array
-    IFS=$'\n;' read -rd '' -a prompt_command_array <<< "$PROMPT_COMMAND"
+    IFS=$'\n;' read -rd '' -a prompt_command_array <<< "${PROMPT_COMMAND:-}"
 
     local trimmed_arg
     __bp_trim_whitespace trimmed_arg "${1:-}"
@@ -297,7 +297,8 @@ __bp_install() {
 
     local existing_prompt_command
     # Remove setting our trap install string and sanitize the existing prompt command string
-    existing_prompt_command="${PROMPT_COMMAND//$__bp_install_string[;$'\n']}" # Edge case of appending to PROMPT_COMMAND
+    existing_prompt_command="${PROMPT_COMMAND:-}"
+    existing_prompt_command="${existing_prompt_command//$__bp_install_string[;$'\n']}" # Edge case of appending to PROMPT_COMMAND
     existing_prompt_command="${existing_prompt_command//$__bp_install_string}"
     __bp_sanitize_string existing_prompt_command "$existing_prompt_command"
 
@@ -328,7 +329,7 @@ __bp_install_after_session_init() {
     __bp_require_not_readonly PROMPT_COMMAND HISTCONTROL HISTTIMEFORMAT || return
 
     local sanitized_prompt_command
-    __bp_sanitize_string sanitized_prompt_command "$PROMPT_COMMAND"
+    __bp_sanitize_string sanitized_prompt_command "${PROMPT_COMMAND:-}"
     if [[ -n "$sanitized_prompt_command" ]]; then
         PROMPT_COMMAND=${sanitized_prompt_command}$'\n'
     fi;


### PR DESCRIPTION
Expressly handle if $PROMPT_COMMAND is previously undefined. This is a follow-on to #101. Alsö, declare the function arrays so that other scripts which depend on this one don't have to deal with them being unbound until the first prompt.