### PR TITLE
Update to remove shellcheck warnings

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -32,6 +32,9 @@
 #  using: the "DEBUG" trap, and the "PROMPT_COMMAND" variable. If you override
 #  either of these after bash-preexec has been installed it will most likely break.
 
+# Tell shellcheck what kind of file this is.
+# shellcheck shell=bash
+
 # Make sure this is bash that's running and return otherwise.
 # Use POSIX syntax for this line:
 if [ -z "${BASH_VERSION-}" ]; then

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -245,8 +245,7 @@ __bp_preexec_invoke_exec() {
     local this_command
     this_command=$(
         export LC_ALL=C
-        # shellcheck disable=SC1007
-        HISTTIMEFORMAT= builtin history 1 | sed '1 s/^ *[0-9][0-9]*[* ] //'
+        HISTTIMEFORMAT='' builtin history 1 | sed '1 s/^ *[0-9][0-9]*[* ] //'
     )
 
     # Sanity check to make sure we have something to invoke our function with.

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -291,7 +291,8 @@ __bp_install() {
     trap '__bp_preexec_invoke_exec "$_"' DEBUG
 
     # Preserve any prior DEBUG trap as a preexec function
-    local prior_trap=$(sed "s/[^']*'\(.*\)'[^']*/\1/" <<<"${__bp_trap_string:-}")
+    local prior_trap
+	prior_trap=$(sed "s/[^']*'\(.*\)'[^']*/\1/" <<<"${__bp_trap_string:-}")
     unset __bp_trap_string
     if [[ -n "$prior_trap" ]]; then
         eval '__bp_original_debug_trap() {

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -138,8 +138,8 @@ __bp_interactive_mode() {
 __bp_precmd_invoke_cmd() {
     # Save the returned value from our last command, and from each process in
     # its pipeline. Note: this MUST be the first thing done in this function.
-	# BP_PIPESTATUS may be unused, ignore
-	# shellcheck disable=SC2034
+    # BP_PIPESTATUS may be unused, ignore
+    # shellcheck disable=SC2034
 
     __bp_last_ret_value="$?" BP_PIPESTATUS=("${PIPESTATUS[@]}")
 
@@ -245,7 +245,7 @@ __bp_preexec_invoke_exec() {
     local this_command
     this_command=$(
         export LC_ALL=C
-		# shellcheck disable=SC1007
+        # shellcheck disable=SC1007
         HISTTIMEFORMAT= builtin history 1 | sed '1 s/^ *[0-9][0-9]*[* ] //'
     )
 
@@ -293,8 +293,8 @@ __bp_install() {
     # Preserve any prior DEBUG trap as a preexec function
     local prior_trap
     # we can't easily do this with variable expansion. Leaving as sed command.
-	# shellcheck disable=SC2001
-	prior_trap=$(sed "s/[^']*'\(.*\)'[^']*/\1/" <<<"${__bp_trap_string:-}")
+    # shellcheck disable=SC2001
+    prior_trap=$(sed "s/[^']*'\(.*\)'[^']*/\1/" <<<"${__bp_trap_string:-}")
     unset __bp_trap_string
     if [[ -n "$prior_trap" ]]; then
         eval '__bp_original_debug_trap() {
@@ -320,7 +320,7 @@ __bp_install() {
     local existing_prompt_command
     # Remove setting our trap install string and sanitize the existing prompt command string
     existing_prompt_command="${PROMPT_COMMAND:-}"
-	# shellcheck disable=SC1087
+    # shellcheck disable=SC1087
     existing_prompt_command="${existing_prompt_command//$__bp_install_string[;$'\n']}" # Edge case of appending to PROMPT_COMMAND
     existing_prompt_command="${existing_prompt_command//$__bp_install_string}"
     __bp_sanitize_string existing_prompt_command "$existing_prompt_command"

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -320,6 +320,7 @@ __bp_install() {
     local existing_prompt_command
     # Remove setting our trap install string and sanitize the existing prompt command string
     existing_prompt_command="${PROMPT_COMMAND:-}"
+	# shellcheck disable=SC1087
     existing_prompt_command="${existing_prompt_command//$__bp_install_string[;$'\n']}" # Edge case of appending to PROMPT_COMMAND
     existing_prompt_command="${existing_prompt_command//$__bp_install_string}"
     __bp_sanitize_string existing_prompt_command "$existing_prompt_command"

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -245,6 +245,7 @@ __bp_preexec_invoke_exec() {
     local this_command
     this_command=$(
         export LC_ALL=C
+		# shellcheck disable=SC1007
         HISTTIMEFORMAT= builtin history 1 | sed '1 s/^ *[0-9][0-9]*[* ] //'
     )
 

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -171,7 +171,7 @@ __bp_precmd_invoke_cmd() {
 # precmd functions. This is available for instance in zsh. We can simulate it in bash
 # by setting the value here.
 __bp_set_ret_value() {
-    return ${1:-}
+    return "${1:-}"
 }
 
 __bp_in_prompt_command() {

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -138,6 +138,9 @@ __bp_interactive_mode() {
 __bp_precmd_invoke_cmd() {
     # Save the returned value from our last command, and from each process in
     # its pipeline. Note: this MUST be the first thing done in this function.
+	# BP_PIPESTATUS may be unused, ignore
+	# shellcheck disable=SC2034
+
     __bp_last_ret_value="$?" BP_PIPESTATUS=("${PIPESTATUS[@]}")
 
     # Don't invoke precmds if we are inside an execution of an "original

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -292,6 +292,8 @@ __bp_install() {
 
     # Preserve any prior DEBUG trap as a preexec function
     local prior_trap
+    # we can't easily do this with variable expansion. Leaving as sed command.
+	# shellcheck disable=SC2001
 	prior_trap=$(sed "s/[^']*'\(.*\)'[^']*/\1/" <<<"${__bp_trap_string:-}")
     unset __bp_trap_string
     if [[ -n "$prior_trap" ]]; then


### PR DESCRIPTION
Hi,
I went ahead and fixed the shellcheck warnings mentioned in https://github.com/rcaloras/bash-preexec/issues/132

Changes to actual code were minimal (couple of quotes and a newline I think).

Test suite runs correctly on my system.
 bats test
 ✓ sourcing bash-preexec should exit with 1 if we're not using bash 
 ✓ __bp_install should exit if it's already installed 
 ✓ __bp_install should remove trap logic and itself from PROMPT_COMMAND 
 ✓ __bp_install should preserve an existing DEBUG trap 
 ✓ __bp_sanitize_string should remove semicolons and trim space 
 ✓ Appending to PROMPT_COMMAND should work after bp_install 
 ✓ Appending or prepending to PROMPT_COMMAND should work after bp_install_after_session_init 
 ✓ Adding to PROMPT_COMMAND before and after initiating install 
 ✓ Adding to PROMPT_COMMAND after with semicolon 
 ✓ during install PROMPT_COMMAND and precmd functions should be executed each once 
 ✓ No functions defined for preexec should simply return 
 ✓ precmd should execute a function once 
 ✓ precmd should set $? to be the previous exit code 
 ✓ precmd should set $BP_PIPESTATUS to the previous $PIPESTATUS 
 ✓ precmd should set $_ to be the previous last arg 
 ✓ preexec should execute a function with the last command in our history 
 ✓ preexec should execute multiple functions in the order added to their arrays 
 ✓ preecmd should execute multiple functions in the order added to their arrays 
 ✓ preexec should execute a function with IFS defined to local scope 
 ✓ precmd should execute a function with IFS defined to local scope 
 ✓ preexec should set $? to be the exit code of preexec_functions 
 ✓ in_prompt_command should detect if a command is part of PROMPT_COMMAND 
 ✓ __bp_adjust_histcontrol should remove ignorespace and ignoreboth 
 ✓ preexec should respect HISTTIMEFORMAT 
 ✓ preexec should not strip whitespace from commands 
 ✓ preexec should preserve multi-line strings in commands 
 ✓ preexec should work on options to 'echo' commands 
 ✓ should not import if it's already defined 
 ✓ should import if not defined 
 ✓ bp should stop installation if HISTTIMEFORMAT is readonly 

30 tests, 0 failures
