### PR TITLE
Check Bash version 3.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Bash-Preexec 
 ============
 
-**preexec** and **precmd** hook functions for Bash in the style of Zsh. They aim to emulate the behavior [as described for Zsh](http://zsh.sourceforge.net/Doc/Release/Functions.html#Hook-Functions).
+**preexec** and **precmd** hook functions for Bash 3.1+ in the style of Zsh. They aim to emulate the behavior [as described for Zsh](http://zsh.sourceforge.net/Doc/Release/Functions.html#Hook-Functions).
 
 <a href="https://bashhub.com" target="_blank"><img src="https://bashhub.com/assets/images/bashhub-logo.png" alt="Bashhub Logo" width="200"></a>
 

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -41,6 +41,12 @@ if [ -z "${BASH_VERSION-}" ]; then
     return 1;
 fi
 
+# We only support Bash 3.1+.
+# Note: BASH_VERSINFO is first available in Bash-2.0.
+if [[ -z "${BASH_VERSINFO-}" || BASH_VERSINFO[0] -lt 3 || BASH_VERSINFO[0] -eq 3 && BASH_VERSINFO[1] -lt 1 ]]; then
+    return 1
+fi
+
 # Avoid duplicate inclusion
 if [[ -n "${bash_preexec_imported:-}" ]]; then
     return 0

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -39,6 +39,16 @@ set_exit_code_and_run_precmd() {
   [ -z "$output" ]
 }
 
+@test "sourcing bash-preexec should exit with 1 if we're using an older version of bash" {
+  if type -p bash-3.0 &>/dev/null; then
+    run bash-3.0 -c "source \"${BATS_TEST_DIRNAME}/../bash-preexec.sh\""
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+  else
+    skip
+  fi
+}
+
 @test "__bp_install should exit if it's already installed" {
   bp_install
 


### PR DESCRIPTION
As discussed in https://github.com/rcaloras/bash-preexec/pull/129#issuecomment-1046169131 and https://github.com/rcaloras/bash-preexec/pull/129#issuecomment-1109971595, the current codebase relies on Bash 3.1 features. In this PR, I mention it in README and check the Bash version in the beginning of the script.
