### PR TITLE
Addtional fixes for `shellcheck`

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -269,7 +269,7 @@ __bp_preexec_invoke_exec() {
         # Only execute each function if it actually exists.
         # Test existence of function with: declare -[fF]
         if type -t "$preexec_function" 1>/dev/null; then
-            __bp_set_ret_value ${__bp_last_ret_value:-}
+            __bp_set_ret_value "${__bp_last_ret_value:-}"
             # Quote our function invocation to prevent issues with IFS
             "$preexec_function" "$this_command"
             preexec_function_ret_value="$?"

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -178,7 +178,7 @@ __bp_precmd_invoke_cmd() {
 # precmd functions. This is available for instance in zsh. We can simulate it in bash
 # by setting the value here.
 __bp_set_ret_value() {
-    return "${1:-}"
+    return ${1:+"$1"}
 }
 
 __bp_in_prompt_command() {

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -55,6 +55,7 @@ bash_preexec_imported="defined"
 
 # WARNING: This variable is no longer used and should not be relied upon.
 # Use ${bash_preexec_imported} instead.
+# shellcheck disable=SC2034
 __bp_imported="${bash_preexec_imported}"
 
 # Should be available to each precmd and preexec

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -326,8 +326,7 @@ __bp_install() {
     local existing_prompt_command
     # Remove setting our trap install string and sanitize the existing prompt command string
     existing_prompt_command="${PROMPT_COMMAND:-}"
-    # shellcheck disable=SC1087
-    existing_prompt_command="${existing_prompt_command//$__bp_install_string[;$'\n']}" # Edge case of appending to PROMPT_COMMAND
+    existing_prompt_command="${existing_prompt_command//${__bp_install_string}[;$'\n']}" # Edge case of appending to PROMPT_COMMAND
     existing_prompt_command="${existing_prompt_command//$__bp_install_string}"
     __bp_sanitize_string existing_prompt_command "$existing_prompt_command"
 


### PR DESCRIPTION
- 9c6e5d7 Maybe due to the difference of the shellcheck versions, but shellcheck-0.7.2 in my environment reports SC2034 also for this line.
- 84ef2b1 `disable=SC2034` has been applied to `__bp_last_ret_value` in addition to `BP_PIPESTATUS`. It would be better to apply it only for the intended variable, `BP_PIPESTATUS`.
- fffccd2 I noticed that `return "${1-}"` results in `return ''` and causes an error when `$1` is empty. This is a regression of #135. Instead, we should specify the argument as `${1:+"$1"}`.
- cb8048a This is also subject to word splitting by unexpected `IFS`. We want to quote it as well.
- 16e09f2 I think it is cleaner and readable for beginners to follow the suggestion from `shellcheck` rather than ignoring the warning