### PR TITLE
Fix a test for #131

### DIFF
--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -277,7 +277,7 @@ set_exit_code_and_run_precmd() {
     IFS=_
     name_with_underscores_2() { parts=(2_2); echo $parts; }
     precmd_functions+=(name_with_underscores_2)
-    run '__bp_precmd_invoke_cmd'
+    run set_exit_code_and_run_precmd
     [ $status -eq 0 ]
     [ "$output" == "2 2" ]
 }


### PR DESCRIPTION
This fixes an issue reported in https://github.com/rcaloras/bash-preexec/issues/121#issuecomment-1318281281 by @rycee:

> Thanks, I tester just now with bats 1.8.2 and curiously I get
> 
> ```
> ok 19 preexec should execute a function with IFS defined to local scope
> not ok 20 precmd should execute a function with IFS defined to local scope
> # (in test file test/bash-preexec.bats, line 272)
> #   `[ $status -eq 0 ]' failed
> ok 21 preexec should set $? to be the exit code of preexec_function
> ```

This is an oversight of updating the test for change #131.