### PR TITLE
Fix the test for the Bash version for shellcheck

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -43,7 +43,7 @@ fi
 
 # We only support Bash 3.1+.
 # Note: BASH_VERSINFO is first available in Bash-2.0.
-if [[ -z "${BASH_VERSINFO-}" || BASH_VERSINFO[0] -lt 3 || BASH_VERSINFO[0] -eq 3 && BASH_VERSINFO[1] -lt 1 ]]; then
+if [[ -z "${BASH_VERSINFO-}" ]] || ((BASH_VERSINFO[0] < 3 || BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 1)); then
     return 1
 fi
 

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -43,7 +43,7 @@ fi
 
 # We only support Bash 3.1+.
 # Note: BASH_VERSINFO is first available in Bash-2.0.
-if [[ -z "${BASH_VERSINFO-}" ]] || ((BASH_VERSINFO[0] < 3 || BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 1)); then
+if [[ -z "${BASH_VERSINFO-}" ]] || (( BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 1) )); then
     return 1
 fi
 


### PR DESCRIPTION
I have separated this commit from #141 as suggested by @dimo414 (https://github.com/rcaloras/bash-preexec/pull/141#discussion_r1127193800).

As in the cover of #141, we seem to need to update the version check due to the shellcheck updates:

> *Quoted from https://github.com/rcaloras/bash-preexec/pull/141#issue-1612395608*
>
> ShellCheck seems to have started to complain about `-lt`, `-eq`, etc. in the conditional command `[[ ... ]]`, so I also included a commit ([77aec5f](https://github.com/rcaloras/bash-preexec/commit/77aec5ff212daed4f0471264ee844c00cdaecc8d)) to workaround the shellcheck warning.

Also

> *Quoted from https://github.com/rcaloras/bash-preexec/pull/141#discussion_r1127198702*
>
> I have introduced the version check in #136. At that time, I just used the single conditional command `[[ ... ]]` because it looked simpler to me compare to combining `[[ ... ]] || (( ... ))`. This time, I have checked the updated version check works as expected with Bash 1.14.7, 2.0, 3.0, and 3.1. Bash 1.14.7 doesn't have BASH_VERSINFO, so it is rejected by `[[ -z "${BASH_VERSINFO-}" ]]`. Bash 2.0+ has an arithmetic command `(( ... ))` and seems to work as expected.
