### PR TITLE
Don't load if old version already present (Fixes rcaloras/bash-preexec#146)

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -48,7 +48,7 @@ if [[ -z "${BASH_VERSINFO-}" ]] || (( BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] 
 fi
 
 # Avoid duplicate inclusion
-if [[ -n "${bash_preexec_imported:-}" ]]; then
+if [[ -n "${bash_preexec_imported:-}" || -n "${__bp_imported:-}" ]]; then
     return 0
 fi
 bash_preexec_imported="defined"

--- a/test/include-test.bats
+++ b/test/include-test.bats
@@ -6,6 +6,12 @@
   [ -z $(type -t __bp_install) ]
 }
 
+@test "should not import if it's already defined (old guard, don't use elsewhere!)" {
+  __bp_imported="defined"
+  source "${BATS_TEST_DIRNAME}/../bash-preexec.sh"
+  [ -z $(type -t __bp_install) ]
+}
+
 @test "should import if not defined" {
   unset bash_preexec_imported
   source "${BATS_TEST_DIRNAME}/../bash-preexec.sh"


### PR DESCRIPTION
This just tests against the old internal-only guard. A possible enhancement would be to also generate an error message in this case, since the user probably wants to use the newer version rather than just silently being left with an old version.