### PR TITLE
Fix false-negative test case for __bp_install

### DIFF
--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -74,13 +74,11 @@ set_exit_code_and_run_precmd() {
 @test "__bp_install should remove trap logic and itself from PROMPT_COMMAND" {
   __bp_install_after_session_init
 
-  [[ "$PROMPT_COMMAND" == *"trap - DEBUG"* ]] || return 1
-  [[ "$PROMPT_COMMAND" == *"__bp_install"* ]] || return 1
+  [[ "$PROMPT_COMMAND" == *"$__bp_install_string"* ]] || return 1
 
   eval_PROMPT_COMMAND
 
-  [[ "$PROMPT_COMMAND" != *"trap - DEBUG"* ]] || return 1
-  [[ "$PROMPT_COMMAND" != *"__bp_install"* ]] || return 1
+  [[ "$PROMPT_COMMAND" != *"$__bp_install_string"* ]] || return 1
 }
 
 @test "__bp_install should preserve an existing DEBUG trap" {

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -74,6 +74,8 @@ set_exit_code_and_run_precmd() {
 @test "__bp_install should remove trap logic and itself from PROMPT_COMMAND" {
   __bp_install_after_session_init
 
+  # Assert that before running, the command contains the install string, and
+  # afterwards it does not
   [[ "$PROMPT_COMMAND" == *"$__bp_install_string"* ]] || return 1
 
   eval_PROMPT_COMMAND

--- a/test/bash-preexec.bats
+++ b/test/bash-preexec.bats
@@ -79,7 +79,7 @@ set_exit_code_and_run_precmd() {
 
   eval_PROMPT_COMMAND
 
-  [[ "$PROMPT_COMMAND" != *"trap DEBUG"* ]] || return 1
+  [[ "$PROMPT_COMMAND" != *"trap - DEBUG"* ]] || return 1
   [[ "$PROMPT_COMMAND" != *"__bp_install"* ]] || return 1
 }
 


### PR DESCRIPTION
This is an oversight of changing `trap DEBUG` to `trap - DEBUG` in

https://github.com/rcaloras/bash-preexec/pull/106

The oversight did not cause a test error because the test always succeeds.  The problem is that even if __bp_install is broken and fails to remove `trap - DEBUG`, the current test case failed to detect the failure and produce a false negative.  This PR fixes it.

----

This fix was first discussed in PR #129 and included as a part of PR #129. However, a reviewer doesn't seem to appear for PR #129, and PR #129 doesn't seem to be going to be merged currently. Because this fix is so trivial that I don't think there is a reason to block further, I separate the fix as an independent PR here.