### PR TITLE
Exclude the `bind -x` commands from interactive commands

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -222,7 +222,7 @@ __bp_preexec_invoke_exec() {
         return
     fi
 
-    if [[ -n "${COMP_LINE:-}" || -n "${READLINE_POINT:-}" ]]; then
+    if [[ -n "${COMP_POINT:-}" || -n "${READLINE_POINT:-}" ]]; then
         # We're in the middle of a completer or a keybinding set up by "bind
         # -x".  This obviously can't be an interactively issued command.
         return

--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -222,9 +222,9 @@ __bp_preexec_invoke_exec() {
         return
     fi
 
-    if [[ -n "${COMP_LINE:-}" ]]; then
-        # We're in the middle of a completer. This obviously can't be
-        # an interactively issued command.
+    if [[ -n "${COMP_LINE:-}" || -n "${READLINE_POINT:-}" ]]; then
+        # We're in the middle of a completer or a keybinding set up by "bind
+        # -x".  This obviously can't be an interactively issued command.
         return
     fi
     if [[ -z "${__bp_preexec_interactive_mode:-}" ]]; then


### PR DESCRIPTION
## Issue: preexec is called for keybindings set up by `bind -x`

Consider the following setup:

```bash
# bashrc

source bash-preexec.sh
function preexec { echo "==== $FUNCNAME ($1) ===="; }
function precmd { echo "==== $FUNCNAME ===="; }

function something { return 0; }
bind -x '"\C-t": something'
```

When I start a session with the above rcfile (`bashrc.exclude-bind-x`) and input <kbd>"echo 1" RET C-t "echo 2" RET C-d</kbd>, the result becomes this:

```bash
[murase@chatoyancy 1 bash-preexec]$ bash --rcfile bashrc.exclude-bind-x
==== precmd ====
[murase@chatoyancy 0 bash-preexec]$ echo 1
==== preexec (echo 1) ====
1
==== precmd ====
==== preexec (echo 1) ====
[murase@chatoyancy 0 bash-preexec]$ echo 2
2
==== precmd ====
[murase@chatoyancy 0 bash-preexec]$
exit
```

The second `preexec` is supposed to be called against the second command `echo 2`, but it's instead called for the command of the keybinding `something`, which is not an expected behavior.

This problem was identified based on the report at https://github.com/atuinsh/atuin/issues/1003#issuecomment-1947905213.

## Solution

We can take the same solution as completion functions. For the completion functions, we are using `COMP_LINE` to test whether we are currently running the completion function. For the `bind -x` commands, we can test `READLINE_POINT` to test whether we are running a command for keybindings.

This solution can be broken when the user sets the shell variable `READLINE_POINT`,  but it's not a problem specific to this PR. The existing code for `COMP_LINE` has the same problem when the user sets the variable. In reality, there shouldn't be many cases where the user sets `READLINE_POINT` outside the keybinding functions. Rather there are more cases where the users set up keybindings through `bind -x`.

Here's the behavior after this fix:

```bash
[murase@chatoyancy 1 bash-preexec]$ bash --rcfile bashrc.exclude-bind-x
==== precmd ====
[murase@chatoyancy 0 bash-preexec]$ echo 1
==== preexec (echo 1) ====
1
==== precmd ====
[murase@chatoyancy 0 bash-preexec]$ echo 2
==== preexec (echo 2) ====
2
==== precmd ====
[murase@chatoyancy 0 bash-preexec]$
exit
```
