### PR TITLE
Fix indentation and remove trailing semicolons

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -38,7 +38,7 @@
 # Make sure this is bash that's running and return otherwise.
 # Use POSIX syntax for this line:
 if [ -z "${BASH_VERSION-}" ]; then
-    return 1;
+    return 1
 fi
 
 # We only support Bash 3.1+.
@@ -76,13 +76,13 @@ __bp_install_string=$'__bp_trap_string="$(trap -p DEBUG)"\ntrap - DEBUG\n__bp_in
 # Fails if any of the given variables are readonly
 # Reference https://stackoverflow.com/a/4441178
 __bp_require_not_readonly() {
-  local var
-  for var; do
-    if ! ( unset "$var" 2> /dev/null ); then
-      echo "bash-preexec requires write access to ${var}" >&2
-      return 1
-    fi
-  done
+    local var
+    for var; do
+        if ! ( unset "$var" 2> /dev/null ); then
+            echo "bash-preexec requires write access to ${var}" >&2
+            return 1
+        fi
+    done
 }
 
 # Remove ignorespace and or replace ignoreboth from HISTCONTROL
@@ -95,7 +95,7 @@ __bp_adjust_histcontrol() {
     # Replace ignoreboth with ignoredups
     if [[ "$histcontrol" == *"ignoreboth"* ]]; then
         histcontrol="ignoredups:${histcontrol//ignoreboth}"
-    fi;
+    fi
     export HISTCONTROL="$histcontrol"
 }
 
@@ -136,7 +136,7 @@ __bp_sanitize_string() {
 # It sets a variable to indicate that the prompt was just displayed,
 # to allow the DEBUG trap to know that the next command is likely interactive.
 __bp_interactive_mode() {
-    __bp_preexec_interactive_mode="on";
+    __bp_preexec_interactive_mode="on"
 }
 
 
@@ -154,7 +154,7 @@ __bp_precmd_invoke_cmd() {
     # prompt command" by another precmd execution loop. This avoids infinite
     # recursion.
     if (( __bp_inside_precmd > 0 )); then
-      return
+        return
     fi
     local __bp_inside_precmd=1
 
@@ -211,7 +211,7 @@ __bp_preexec_invoke_exec() {
     __bp_last_argument_prev_command="${1:-}"
     # Don't invoke preexecs if we are inside of another preexec.
     if (( __bp_inside_preexec > 0 )); then
-      return
+        return
     fi
     local __bp_inside_preexec=1
 
@@ -291,7 +291,7 @@ __bp_preexec_invoke_exec() {
 __bp_install() {
     # Exit if we already have this installed.
     if [[ "${PROMPT_COMMAND[*]:-}" == *"__bp_precmd_invoke_cmd"* ]]; then
-        return 1;
+        return 1
     fi
 
     trap '__bp_preexec_invoke_exec "$_"' DEBUG
@@ -304,7 +304,7 @@ __bp_install() {
     unset __bp_trap_string
     if [[ -n "$prior_trap" ]]; then
         eval '__bp_original_debug_trap() {
-          '"$prior_trap"'
+            '"$prior_trap"'
         }'
         preexec_functions+=(__bp_original_debug_trap)
     fi
@@ -321,7 +321,7 @@ __bp_install() {
         # Set so debug trap will work be invoked in subshells.
         set -o functrace > /dev/null 2>&1
         shopt -s extdebug > /dev/null 2>&1
-    fi;
+    fi
 
     local existing_prompt_command
     # Remove setting our trap install string and sanitize the existing prompt command string
@@ -369,7 +369,7 @@ __bp_install_after_session_init() {
     if [[ -n "$sanitized_prompt_command" ]]; then
         # shellcheck disable=SC2178 # PROMPT_COMMAND is not an array in bash <= 5.0
         PROMPT_COMMAND=${sanitized_prompt_command}$'\n'
-    fi;
+    fi
     # shellcheck disable=SC2179 # PROMPT_COMMAND is not an array in bash <= 5.0
     PROMPT_COMMAND+=${__bp_install_string}
 }
@@ -377,4 +377,4 @@ __bp_install_after_session_init() {
 # Run our install so long as we're not delaying it.
 if [[ -z "${__bp_delay_install:-}" ]]; then
     __bp_install_after_session_init
-fi;
+fi


### PR DESCRIPTION
A few lines have the 2-space indentation. We fix them in this PR.

Also, several lines have suffix semicolons. Those semicolons might have been added by e.g. `bash --pretty-print bash-preexec.sh`, but we currently don't have such a semicolon for most of the lines anyway. There are two options for consistency:

- We suffix semicolons to every line that can have a semicolon.
- Or we remove all unnecessary semicolons.

In this PR, we choose the latter, the majority.