### PR TITLE
Use `command` to execute `sed`

### DIFF
--- a/bash-preexec.sh
+++ b/bash-preexec.sh
@@ -300,7 +300,7 @@ __bp_install() {
     local prior_trap
     # we can't easily do this with variable expansion. Leaving as sed command.
     # shellcheck disable=SC2001
-    prior_trap=$(sed "s/[^']*'\(.*\)'[^']*/\1/" <<<"${__bp_trap_string:-}")
+    prior_trap=$(builtin command sed "s/[^']*'\(.*\)'[^']*/\1/" <<<"${__bp_trap_string:-}")
     unset __bp_trap_string
     if [[ -n "$prior_trap" ]]; then
         eval '__bp_original_debug_trap() {


### PR DESCRIPTION
We want our execution environment to be a predictable as possible. Similar to how we use `builtin` to ensure we're running the shell's builtin function (and not a redefinition), use `command` to ensure we're running `sed` and not a shell function or alias.