### PR TITLE
GitHub workflow: Update runner 20.04 -> 24.04

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install Bats
         run: |


### PR DESCRIPTION
20.04 runner has been deprecated.  For details see:

https://github.com/actions/runner-images/issues/11101