### PR TITLE
Use bats-core/bats-action to set up Bats

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -3,13 +3,11 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Bats
-        run: |
-          sudo apt-get update
-          sudo apt-get install --assume-yes bats
+        uses: bats-core/bats-action@3.0.1
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Run tests
         run: bats test


### PR DESCRIPTION
This is the "official" (under the bats-core organization) GitHub Action for setting up Bats in a workflow. This removes the need to manually install the `bats` package.

Also, update to the latest actions/checkout version and use the latest Ubuntu image.